### PR TITLE
Feature/chapter11 resolving and binding

### DIFF
--- a/VM/run.go
+++ b/VM/run.go
@@ -6,6 +6,7 @@ import (
 	"golox/lox/interpreter"
 	"golox/lox/lexer"
 	"golox/lox/parser"
+	"golox/lox/resolver"
 	"golox/utils"
 	"os"
 )
@@ -15,6 +16,7 @@ type VM struct {
 	hadRuntimeError bool
 	vmLexer         *lexer.Lexer
 	vmParser        *parser.Parser
+	vmResolver      *resolver.Resolver
 	vmInterpreter   *interpreter.Interpreter
 }
 
@@ -77,6 +79,16 @@ func (v *VM) run(source string) {
 	}
 
 	v.vmInterpreter = interpreter.NewInterpreter()
+	v.vmResolver = resolver.NewResolver(v.vmInterpreter)
+
+	_, err := v.vmResolver.Resolve(statements)
+	if err != nil {
+		v.hadError = true
+	}
+	if v.hadError {
+		return
+	}
+
 	runtimeError := v.vmInterpreter.Interpret(statements)
 
 	if runtimeError.HasError {

--- a/lox/environment/environment.go
+++ b/lox/environment/environment.go
@@ -29,6 +29,10 @@ func (e *Environment) Get(name lexer.Token) (interface{}, error) {
 	return nil, common.RuntimeError{HasError: true, Token: name, Reason: "Undefined variable '" + name.Lexeme + "'"}
 }
 
+func (e *Environment) GetAt(distance int, name string) interface{} {
+	return e.ancestor(distance)[name]
+}
+
 func (e *Environment) Define(name string, value interface{}) {
 	e.values[name] = value
 }

--- a/lox/environment/environment.go
+++ b/lox/environment/environment.go
@@ -30,7 +30,11 @@ func (e *Environment) Get(name lexer.Token) (interface{}, error) {
 }
 
 func (e *Environment) GetAt(distance int, name string) interface{} {
-	return e.ancestor(distance)[name]
+	return e.ancestor(distance).values[name]
+}
+
+func (e *Environment) AssignAt(distance int, name lexer.Token, value interface{}) {
+	e.ancestor(distance).values[name.Lexeme] = value
 }
 
 func (e *Environment) Define(name string, value interface{}) {
@@ -47,4 +51,12 @@ func (e *Environment) Assign(name lexer.Token, value interface{}) error {
 		return e.enclosing.Assign(name, value)
 	}
 	return common.RuntimeError{HasError: true, Token: name, Reason: "Undefined variable '" + name.Lexeme + "'"}
+}
+
+func (e *Environment) ancestor(distance int) *Environment {
+	current := e
+	for i := 0; i < distance; i++ {
+		current = current.enclosing
+	}
+	return current
 }

--- a/lox/parser/parser.go
+++ b/lox/parser/parser.go
@@ -129,9 +129,6 @@ func (p *Parser) forStatement() (ast.Stmt, error) {
 		return nil, err
 	}
 
-	if incremental != nil {
-		body = &ast.Block{Statements: []ast.Stmt{body}}
-	}
 	if condition == nil {
 		condition = &ast.Literal{Type: lexer.TRUE, Value: true}
 	}

--- a/lox/resolver/resolver.go
+++ b/lox/resolver/resolver.go
@@ -1,0 +1,293 @@
+package resolver
+
+import (
+	"errors"
+	"golox/lox/ast"
+	"golox/lox/interpreter"
+	"golox/lox/lexer"
+	"golox/utils"
+)
+
+type Resolver struct {
+	interpreter interpreter.Interpreter
+	scopes      []map[string]bool
+}
+
+func (i *Resolver) VisitExpressionStmt(stmt *ast.Expression) (interface{}, error) {
+	_, err := i.resolve(stmt.Expression)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitIfStmt(stmt *ast.If) (interface{}, error) {
+	var err error
+	_, err = i.resolve(stmt.Condition)
+	if err != nil {
+		return nil, err
+	}
+	_, err = i.resolve(stmt.ThenBranch)
+	if err != nil {
+		return nil, err
+	}
+	if stmt.ElseBranch != nil {
+		_, err = i.resolve(stmt.ThenBranch)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitPrintStmt(stmt *ast.Print) (interface{}, error) {
+	_, err := i.resolve(stmt.Expression)
+	return nil, err
+}
+
+func (i *Resolver) VisitReturnStmt(stmt *ast.Return) (interface{}, error) {
+	if stmt.Value != nil {
+		_, err := i.resolve(stmt.Value)
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitWhileStmt(stmt *ast.While) (interface{}, error) {
+	_, err := i.resolve(stmt.Condition)
+	if err != nil {
+		return nil, err
+	}
+	_, err = i.resolve(stmt.Body)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitBreakStmt(_ *ast.Break) (interface{}, error) {
+	return nil, nil
+}
+
+func (i *Resolver) VisitContinueStmt(_ *ast.Continue) (interface{}, error) {
+	return nil, nil
+}
+
+func (i *Resolver) VisitBinaryExpr(expr *ast.Binary) (interface{}, error) {
+	_, err := i.resolve(expr.Left)
+	if err != nil {
+		return nil, err
+	}
+	_, err = i.resolve(expr.Right)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitCallExpr(expr *ast.Call) (interface{}, error) {
+	_, err := i.resolve(expr.Callee)
+	if err != nil {
+		return nil, err
+	}
+	for _, argument := range expr.Arguments {
+		_, err = i.resolve(argument)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitGroupingExpr(expr *ast.Grouping) (interface{}, error) {
+	_, err := i.resolve(expr.Expression)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitLiteralExpr(_ *ast.Literal) (interface{}, error) {
+	return nil, nil
+}
+
+func (i *Resolver) VisitLogicalExpr(expr *ast.Logical) (interface{}, error) {
+	_, err := i.resolve(expr.Left)
+	if err != nil {
+		return nil, err
+	}
+	_, err = i.resolve(expr.Right)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitUnaryExpr(expr *ast.Unary) (interface{}, error) {
+	_, err := i.resolve(expr.Right)
+	return nil, err
+}
+
+func (i *Resolver) VisitAssignExpr(expr *ast.Assign) (interface{}, error) {
+	_, err := i.resolve(expr.Value)
+	if err != nil {
+		return nil, err
+	}
+	_, err = i.resolveLocal(expr, expr.Name)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitTernaryExpr(expr *ast.Ternary) (interface{}, error) {
+	_, err := i.resolve(expr.ConditionalExpr)
+	if err != nil {
+		return nil, err
+	}
+	_, err = i.resolve(expr.ElseExpr)
+	if err != nil {
+		return nil, err
+	}
+	if expr.ThenExpr != nil {
+		_, err = i.resolve(expr.ThenExpr)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitFunctionExpr(expr *ast.FunctionExpr) (interface{}, error) {
+	i.beginScope()
+	for _, param := range expr.Params {
+		i.declare(param)
+		i.define(param)
+	}
+	_, err := i.resolve(expr.Body)
+	if err != nil {
+		return nil, err
+	}
+	i.endScope()
+	return nil, nil
+}
+
+func NewResolver(interpreter interpreter.Interpreter) *Resolver {
+	return &Resolver{interpreter: interpreter}
+}
+
+func (i *Resolver) VisitBlockStmt(stmt *ast.Block) (interface{}, error) {
+	i.beginScope()
+	_, err := i.resolve(stmt.Statements)
+	if err != nil {
+		return nil, err
+	}
+	i.endScope()
+	return nil, nil
+}
+
+func (i *Resolver) VisitVarStmt(stmt *ast.Var) (interface{}, error) {
+	i.declare(stmt.Name)
+	if stmt.Initializer != nil {
+		_, err := i.resolve(stmt.Initializer)
+		if err != nil {
+			return nil, err
+		}
+	}
+	i.define(stmt.Name)
+	return nil, nil
+}
+
+func (i *Resolver) VisitVariableExpr(expr *ast.Variable) (interface{}, error) {
+	if len(i.scopes) > 0 {
+		scope := i.scopes[len(i.scopes)-1]
+		if ok, v := scope[expr.Name.Lexeme]; ok {
+			if !v {
+				utils.Report(expr.Name.Line, "Resolver", "Can't read local variable in its own initializer")
+			}
+		}
+	}
+	_, err := i.resolveLocal(expr, expr.Name)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) VisitFunctionStmt(stmt *ast.Function) (interface{}, error) {
+	i.declare(stmt.Name)
+	i.define(stmt.Name)
+	_, err := i.resolveFunction(stmt)
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func (i *Resolver) resolve(obj interface{}) (interface{}, error) {
+	switch v := obj.(type) {
+	case []ast.Stmt:
+		for _, statement := range v {
+			_, err := i.resolve(statement)
+			if err != nil {
+				return nil, err
+			}
+		}
+	case ast.Stmt:
+		return v.Accept(i)
+	case ast.Expr:
+		return v.Accept(i)
+	}
+	utils.Report(-1, "Resolver#resolve", "Impossible code reached")
+	return nil, errors.New("impossible code reached")
+}
+
+func (i *Resolver) resolveFunction(function *ast.Function) (interface{}, error) {
+	i.beginScope()
+	for _, param := range function.Params {
+		i.declare(param)
+		i.define(param)
+	}
+	_, err := i.resolve(function.Body)
+	if err != nil {
+		return nil, err
+	}
+	i.endScope()
+	return nil, nil
+}
+
+func (i *Resolver) resolveLocal(expr ast.Expr, name lexer.Token) (interface{}, error) {
+	for index := len(i.scopes) - 1; index >= 0; index-- {
+		if ok, _ := i.scopes[index][name.Lexeme]; ok {
+			i.interpreter.Resolve(expr, len(i.scopes)-1-index)
+		}
+	}
+	return nil, nil
+}
+
+func (i *Resolver) beginScope() {
+	i.scopes = append(i.scopes, make(map[string]bool, 0))
+}
+
+func (i *Resolver) endScope() {
+	i.scopes = i.scopes[:len(i.scopes)-1]
+}
+
+func (i *Resolver) declare(name lexer.Token) {
+	if len(i.scopes) == 0 {
+		return
+	}
+	scope := i.scopes[len(i.scopes)-1]
+	scope[name.Lexeme] = false
+	i.scopes[len(i.scopes)-1] = scope
+
+}
+
+func (i *Resolver) define(name lexer.Token) {
+	if len(i.scopes) == 0 {
+		return
+	}
+	scope := i.scopes[len(i.scopes)-1]
+	scope[name.Lexeme] = true
+	i.scopes[len(i.scopes)-1] = scope
+}

--- a/tests/code_test.go
+++ b/tests/code_test.go
@@ -274,6 +274,23 @@ whichFn(named);
 	vm.RunStr(snippet)
 }
 
+func TestClosureWithVar(t *testing.T) {
+	snippet := `
+var a = "global";
+{
+  fun showA() {
+    print a;
+  }
+
+  showA();
+  var a = "block";
+  showA();
+}
+`
+	vm := &VM.VM{}
+	vm.RunStr(snippet)
+}
+
 /* no `;` at end of line */
 func TestMalformedCodeSnippet1(t *testing.T) {
 	snippet := `// Your first Lox program!

--- a/tests/encoding_test.go
+++ b/tests/encoding_test.go
@@ -30,8 +30,5 @@ func TestFor(t *testing.T) {
 }
 
 func TestBreak(t *testing.T) {
-	for 1 < 2 {
-		break
-	}
 
 }


### PR DESCRIPTION
1. Finish Chapter11 goal of adding resolver.go to achieve semantic analysis after doing parsing or know as syntactic analysis
2. BUG: The original tutorial use syntax candy to transfer `FOR` loop to `WHILE` loop and put mutate statement in `FOR` into the end of the converted  `WHILE` body which will result infinite loop if we add `BREAK` statement. `CONTINUE` will immediately exit loop and will not execute the mutate  statement as desired in `FOR` loop.
FIX: Add `OptionalMutate` resolving in resolver.go
3. Warn user some possible misuse situations